### PR TITLE
`v0.6.0-path-prefix`: Prefix all routes via path_prefix setting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,11 @@ repos:
         language_version: python
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.812
+    rev: v0.971
     hooks:
       - id: mypy
         language_version: python
+        additional_dependencies:
+          - types-simplejson
+          - types-attrs
+          - types-requests

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script compiles the service into a Python Lambda build artifact
+
+set -ex
+
+SERVICE_NAME=titiler
+
+# VERSION
+if [ "$TRAVIS" = "true" ]; then
+  # Explicitly checkout git branch for versioning:
+  git checkout ${TRAVIS_BRANCH}
+fi
+VERSION=$(wget -O - https://github.com/SenteraLLC/build-support/raw/v1.2.0/version.sh | bash)
+VERSION_TAG=$(printf $VERSION | perl -pe 's/[^\w.-]/_/g')
+DOCKER_TAG=${SERVICE_NAME}:${VERSION_TAG}
+
+PROJ_DIR=$(git rev-parse --show-toplevel)
+BUILD_DIR=${PROJ_DIR}/build
+LAMBDA_PATH=${PROJ_DIR}/package.zip
+
+cd ${PROJ_DIR}
+rm -rf ${BUILD_DIR}
+mkdir -p $(dirname ${BUILD_DIR})
+rm -f ${LAMBDA_PATH}
+mkdir -p $(dirname ${LAMBDA_PATH})
+
+# Build Docker image and copy build assets out:
+cd ${PROJ_DIR}/deployment/aws
+docker build -f ${PROJ_DIR}/deployment/aws/lambda/Dockerfile -t ${DOCKER_TAG} .
+docker run --rm -it -v ${BUILD_DIR}:/asset-output --entrypoint /bin/bash ${DOCKER_TAG} -c 'cp -R /asset/. /asset-output/.'
+
+# Package up into .zip:
+cd ${BUILD_DIR}
+zip -r ${LAMBDA_PATH} .

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -27,7 +27,7 @@ mkdir -p $(dirname ${LAMBDA_PATH})
 
 # Build Docker image and copy build assets out:
 cd ${PROJ_DIR}/deployment/aws
-docker build -f ${PROJ_DIR}/deployment/aws/lambda/Dockerfile -t ${DOCKER_TAG} .
+docker build --no-cache -f ${PROJ_DIR}/deployment/aws/lambda/Dockerfile -t ${DOCKER_TAG} .
 docker run --rm -it -v ${BUILD_DIR}:/asset-output --entrypoint /bin/bash ${DOCKER_TAG} -c 'cp -R /asset/. /asset-output/.'
 
 # Package up into .zip:

--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 
 RUN pip install pip -U
-RUN pip install "https://github.com/SenteraLLC/titiler/archive/v0.6.0-path-prefix.tar.gz" "mangum>=0.10.0" -t /asset --no-binary pydantic
+RUN pip install "https://github.com/SenteraLLC/titiler/archive/path-prefix.tar.gz" "mangum>=0.10.0" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;

--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 
 RUN pip install pip -U
-RUN pip install "titiler.application==0.6.0" "mangum>=0.10.0" -t /asset --no-binary pydantic
+RUN pip install "https://github.com/SenteraLLC/titiler/archive/v0.6.0-path-prefix.tar.gz" "mangum>=0.10.0" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;

--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -5,7 +5,7 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 
 RUN pip install pip -U
-RUN pip install "https://github.com/SenteraLLC/titiler/archive/path-prefix.tar.gz" "mangum>=0.10.0" -t /asset --no-binary pydantic
+RUN pip install "https://github.com/SenteraLLC/titiler/archive/refs/tags/v0.6.0-path-prefix.tar.gz" "mangum>=0.10.0" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[2-3][0-9]//'); cp $f $n; done;

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ with open("README.md") as f:
 __version__ = "0.6.0"
 
 inst_reqs = [
-    f"titiler.core=={__version__}",
-    f"titiler.mosaic=={__version__}",
-    f"titiler.application=={__version__}",
+    f"titiler.core @ file://localhost/{os.getcwd()}/src/titiler/core",
+    f"titiler.mosaic @ file://localhost/{os.getcwd()}/src/titiler/mosaic",
+    f"titiler.application @ file://localhost/{os.getcwd()}/src/titiler/application",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 """Setup titiler metapackage."""
 
+import os
+
 from setuptools import setup
 
 with open("README.md") as f:

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -16,7 +16,7 @@ from titiler.core.middleware import (
 )
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
-from fastapi import FastAPI, APIRouter
+from fastapi import APIRouter, FastAPI
 
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -56,15 +56,25 @@ app = FastAPI(
 )
 
 if not api_settings.disable_cog:
-    app.include_router(cog.router, prefix=api_settings.path_prefix+"/cog", tags=["Cloud Optimized GeoTIFF"])
+    app.include_router(
+        cog.router,
+        prefix=api_settings.path_prefix + "/cog",
+        tags=["Cloud Optimized GeoTIFF"],
+    )
 
 if not api_settings.disable_stac:
     app.include_router(
-        stac.router, prefix=api_settings.path_prefix+"/stac", tags=["SpatioTemporal Asset Catalog"]
+        stac.router,
+        prefix=api_settings.path_prefix + "/stac",
+        tags=["SpatioTemporal Asset Catalog"],
     )
 
 if not api_settings.disable_mosaic:
-    app.include_router(mosaic.router, prefix=api_settings.path_prefix+"/mosaicjson", tags=["MosaicJSON"])
+    app.include_router(
+        mosaic.router,
+        prefix=api_settings.path_prefix + "/mosaicjson",
+        tags=["MosaicJSON"],
+    )
 
 app.include_router(tms.router, prefix=api_settings.path_prefix, tags=["TileMatrixSets"])
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
@@ -96,7 +106,7 @@ app.add_middleware(
 app.add_middleware(
     CacheControlMiddleware,
     cachecontrol=api_settings.cachecontrol,
-    exclude_path={r"/healthz"},
+    exclude_path={api_settings.path_prefix + "/healthz"},
 )
 
 if api_settings.debug:
@@ -108,6 +118,7 @@ if api_settings.lower_case_query_parameters:
 
 
 router = APIRouter(prefix=api_settings.path_prefix)
+
 
 @router.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping():
@@ -123,5 +134,6 @@ def landing(request: Request):
         context={"request": request},
         media_type="text/html",
     )
+
 
 app.include_router(router)

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -55,9 +55,6 @@ app = FastAPI(
     root_path=api_settings.root_path,
 )
 
-router = APIRouter(prefix=api_settings.path_prefix)
-app.include_router(router)
-
 if not api_settings.disable_cog:
     app.include_router(cog.router, prefix=api_settings.path_prefix+"/cog", tags=["Cloud Optimized GeoTIFF"])
 
@@ -110,6 +107,8 @@ if api_settings.lower_case_query_parameters:
     app.add_middleware(LowerCaseQueryStringMiddleware)
 
 
+router = APIRouter(prefix=api_settings.path_prefix)
+
 @router.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping():
     """Health check."""
@@ -124,3 +123,5 @@ def landing(request: Request):
         context={"request": request},
         media_type="text/html",
     )
+
+app.include_router(router)

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -43,9 +43,10 @@ logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 
 logger = logging.getLogger(__name__)
 logger.info(f"TiTiler")
-logger.info(f"Path prefix: {api_settings.path_prefix}")
 
 api_settings = ApiSettings()
+logger.debug(f"Root path: {api_settings.root_path}")
+logger.debug(f"Path prefix: {api_settings.path_prefix}")
 
 app = FastAPI(
     title=api_settings.name,

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -1,6 +1,7 @@
 """titiler app."""
 
 import logging
+import os
 
 from titiler.application import __version__ as titiler_version
 from titiler.application.custom import templates

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -22,9 +22,27 @@ from starlette.requests import Request
 from starlette.responses import HTMLResponse
 from starlette_cramjam.middleware import CompressionMiddleware
 
+LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+# Remove any AWS-injected logger handlers to fix Lambda logging to CloudWatch
+# https://stackoverflow.com/a/45624044
+base = logging.getLogger()
+if base.handlers:
+    for handler in base.handlers:
+        base.removeHandler(handler)
+logging.basicConfig(level=LEVELS.get(os.environ.get("LOGLEVEL", "info")))
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
 logging.getLogger("rio-tiler").setLevel(logging.ERROR)
+
+logger = logging.getLogger(__name__)
+logger.info(f"TiTiler")
+logger.info(f"Path prefix: {api_settings.path_prefix}")
 
 api_settings = ApiSettings()
 

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -42,7 +42,7 @@ logging.getLogger("botocore.utils").disabled = True
 logging.getLogger("rio-tiler").setLevel(logging.ERROR)
 
 logger = logging.getLogger(__name__)
-logger.info(f"TiTiler")
+logger.info("TiTiler")
 
 api_settings = ApiSettings()
 logger.debug(f"Root path: {api_settings.root_path}")

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -15,7 +15,7 @@ from titiler.core.middleware import (
 )
 from titiler.mosaic.errors import MOSAIC_STATUS_CODES
 
-from fastapi import FastAPI
+from fastapi import FastAPI, APIRouter
 
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -35,18 +35,21 @@ app = FastAPI(
     root_path=api_settings.root_path,
 )
 
+router = APIRouter(prefix=api_settings.path_prefix)
+app.include_router(router)
+
 if not api_settings.disable_cog:
-    app.include_router(cog.router, prefix="/cog", tags=["Cloud Optimized GeoTIFF"])
+    app.include_router(cog.router, prefix=api_settings.path_prefix+"/cog", tags=["Cloud Optimized GeoTIFF"])
 
 if not api_settings.disable_stac:
     app.include_router(
-        stac.router, prefix="/stac", tags=["SpatioTemporal Asset Catalog"]
+        stac.router, prefix=api_settings.path_prefix+"/stac", tags=["SpatioTemporal Asset Catalog"]
     )
 
 if not api_settings.disable_mosaic:
-    app.include_router(mosaic.router, prefix="/mosaicjson", tags=["MosaicJSON"])
+    app.include_router(mosaic.router, prefix=api_settings.path_prefix+"/mosaicjson", tags=["MosaicJSON"])
 
-app.include_router(tms.router, tags=["TileMatrixSets"])
+app.include_router(tms.router, prefix=api_settings.path_prefix, tags=["TileMatrixSets"])
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 add_exception_handlers(app, MOSAIC_STATUS_CODES)
 
@@ -87,13 +90,13 @@ if api_settings.lower_case_query_parameters:
     app.add_middleware(LowerCaseQueryStringMiddleware)
 
 
-@app.get("/healthz", description="Health Check", tags=["Health Check"])
+@router.get("/healthz", description="Health Check", tags=["Health Check"])
 def ping():
     """Health check."""
     return {"ping": "pong!"}
 
 
-@app.get("/", response_class=HTMLResponse, include_in_schema=False)
+@router.get("/", response_class=HTMLResponse, include_in_schema=False)
 def landing(request: Request):
     """TiTiler Landing page"""
     return templates.TemplateResponse(

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -10,6 +10,7 @@ class ApiSettings(pydantic.BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     root_path: str = ""
+    path_prefix: str = ""
     debug: bool = False
 
     disable_cog: bool = False

--- a/src/titiler/core/setup.py
+++ b/src/titiler/core/setup.py
@@ -12,7 +12,7 @@ inst_reqs = [
     "numpy",
     "pydantic",
     "rasterio",
-    "rio-tiler@git+ssh://git@github.com/SenteraLLC/rio-tiler.git@3.1.5",
+    "rio-tiler@https://github.com/SenteraLLC/rio-tiler/archive/3.1.5.tar.gz",
     "simplejson",
     "importlib_resources>=1.1.0;python_version<'3.9'",
     "typing_extensions;python_version<'3.8'",


### PR DESCRIPTION
🚨 **Reminder: This is a public repo** 🚨 

This PR adds the ability to host TiTiler on a non-root API route. The route is configurable via the `TITILER_API_PATH_PREFIX` environment variable.

See:
- Issue developmentseed/titiler#513 for a more thorough description
- PR developmentseed/titiler#515 to make this change in the upstream TiTiler project