### PR TITLE
[PAGC-1757] Re-introduce support for non-root routes and `aoi` tile clipping

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ deployment/*
 docs/*
 
 deployment/aws/**
+!deployment/aws/lambda/handler.py

--- a/build-lambda.sh
+++ b/build-lambda.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script compiles the service into a Python Lambda build artifact
+
+set -ex
+
+PROJ_DIR=$(git rev-parse --show-toplevel)
+BUILD_DIR=${PROJ_DIR}/build
+DOCKER_TAG=titiler_build
+LAMBDA_PATH=${PROJ_DIR}/package.zip
+
+cd ${PROJ_DIR}
+
+# Clean out old build relics
+rm -rf ${BUILD_DIR}
+mkdir -p $(dirname ${BUILD_DIR})
+rm -f ${LAMBDA_PATH}
+mkdir -p $(dirname ${LAMBDA_PATH})
+
+# Build Docker image and copy build assets out:
+docker build --no-cache -f ${PROJ_DIR}/deployment/aws/lambda/Dockerfile -t ${DOCKER_TAG} .
+docker run --rm -it -v ${BUILD_DIR}:/asset-output --entrypoint /bin/bash ${DOCKER_TAG} -c 'cp -R /asset/. /asset-output/.'
+
+# Package up into .zip:
+cd ${BUILD_DIR}
+zip -r ${LAMBDA_PATH} .

--- a/deployment/aws/lambda/Dockerfile
+++ b/deployment/aws/lambda/Dockerfile
@@ -5,7 +5,11 @@ FROM --platform=linux/amd64 public.ecr.aws/lambda/python:${PYTHON_VERSION}
 WORKDIR /tmp
 
 RUN pip install pip -U
-RUN pip install "titiler.application==0.11.6" "mangum>=0.10.0" -t /asset --no-binary pydantic
+# Install TiTiler from local source. This is necessary because
+# pyproject.toml refers to TiTiler dependencies (core, extensions,
+# mosaic, and application) that also use filesystem paths.
+COPY . /titiler
+RUN pip install "/titiler/src/titiler/application" "mangum>=0.10.0" -t /asset --no-binary pydantic
 
 # Reduce package size and remove useless files
 RUN cd /asset && find . -type f -name '*.pyc' | while read f; do n=$(echo $f | sed 's/__pycache__\///' | sed 's/.cpython-[0-9]*//'); cp $f $n; done;
@@ -14,6 +18,6 @@ RUN cd /asset && find . -type f -a -name '*.py' -print0 | xargs -0 rm -f
 RUN find /asset -type d -a -name 'tests' -print0 | xargs -0 rm -rf
 RUN rm -rdf /asset/numpy/doc/ /asset/boto3* /asset/botocore* /asset/bin /asset/geos_license /asset/Misc
 
-COPY lambda/handler.py /asset/handler.py
+COPY deployment/aws/lambda/handler.py /asset/handler.py
 
 CMD ["echo", "hello world"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,12 @@ classifiers = [
 ]
 version="0.11.6"
 dependencies = [
-    "titiler.core==0.11.6",
-    "titiler.extensions==0.11.6",
-    "titiler.mosaic==0.11.6",
-    "titiler.application==0.11.6",
+    # Configured for volume-mount path of Lambda Dockerfile. For local
+    # development, update accordingly for your local filesystem path:
+    "titiler.core @ file:///titiler/src/titiler/core",
+    "titiler.extensions @ file:///titiler/src/titiler/extensions",
+    "titiler.mosaic @ file:///titiler/src/titiler/mosaic",
+    "titiler.application @ file:///titiler/src/titiler/application",
 ]
 
 [project.optional-dependencies]

--- a/src/titiler/application/pyproject.toml
+++ b/src/titiler/application/pyproject.toml
@@ -29,9 +29,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler.core==0.11.6",
-    "titiler.extensions[cogeo,stac]==0.11.6",
-    "titiler.mosaic==0.11.6",
+    # Configured for volume-mount path of Lambda Dockerfile. For local
+    # development, update accordingly for your local filesystem path:
+    "titiler.core @ file:///titiler/src/titiler/core",
+    "titiler.extensions[cogeo,stac] @ file:///titiler/src/titiler/extensions",
+    "titiler.mosaic @ file:///titiler/src/titiler/mosaic",
     "starlette-cramjam>=0.3,<0.4",
     "python-dotenv",
 ]

--- a/src/titiler/application/titiler/application/main.py
+++ b/src/titiler/application/titiler/application/main.py
@@ -1,8 +1,9 @@
 """titiler app."""
 
 import logging
+import os
 
-from fastapi import FastAPI
+from fastapi import APIRouter, FastAPI
 from rio_tiler.io import STACReader
 from starlette.middleware.cors import CORSMiddleware
 from starlette.requests import Request
@@ -40,14 +41,34 @@ except ImportError:
     # Try backported to PY<39 `importlib_resources`.
     from importlib_resources import files as resources_files  # type: ignore
 
+LEVELS = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+# Remove any AWS-injected logger handlers to fix Lambda logging to CloudWatch
+# https://stackoverflow.com/a/45624044
+base = logging.getLogger()
+if base.handlers:
+    for handler in base.handlers:
+        base.removeHandler(handler)
+logging.basicConfig(level=LEVELS.get(os.environ.get("LOGLEVEL", "info")))
 logging.getLogger("botocore.credentials").disabled = True
 logging.getLogger("botocore.utils").disabled = True
 logging.getLogger("rio-tiler").setLevel(logging.ERROR)
+
+logger = logging.getLogger(__name__)
+logger.info("TiTiler")
 
 # TODO: mypy fails in python 3.9, we need to find a proper way to do this
 templates = Jinja2Templates(directory=str(resources_files(__package__) / "templates"))  # type: ignore
 
 api_settings = ApiSettings()
+global_prefix = api_settings.path_prefix
+logger.debug(f"Root path: {api_settings.root_path}")
+logger.debug(f"Path prefix: {global_prefix}")
 
 app = FastAPI(
     title=api_settings.name,
@@ -67,9 +88,10 @@ app = FastAPI(
 
 ###############################################################################
 # Simple Dataset endpoints (e.g Cloud Optimized GeoTIFF)
+cog_prefix = global_prefix + "/cog"
 if not api_settings.disable_cog:
     cog = TilerFactory(
-        router_prefix="/cog",
+        router_prefix=cog_prefix,
         extensions=[
             cogValidateExtension(),
             cogViewerExtension(),
@@ -77,39 +99,41 @@ if not api_settings.disable_cog:
         ],
     )
 
-    app.include_router(cog.router, prefix="/cog", tags=["Cloud Optimized GeoTIFF"])
+    app.include_router(cog.router, prefix=cog_prefix, tags=["Cloud Optimized GeoTIFF"])
 
 
 ###############################################################################
 # STAC endpoints
+stac_prefix = global_prefix + "/stac"
 if not api_settings.disable_stac:
     stac = MultiBaseTilerFactory(
         reader=STACReader,
-        router_prefix="/stac",
+        router_prefix=stac_prefix,
         extensions=[
             stacViewerExtension(),
         ],
     )
 
     app.include_router(
-        stac.router, prefix="/stac", tags=["SpatioTemporal Asset Catalog"]
+        stac.router, prefix=stac_prefix, tags=["SpatioTemporal Asset Catalog"]
     )
 
 ###############################################################################
 # Mosaic endpoints
+mosaicjson_prefix = global_prefix + "/mosaicjson"
 if not api_settings.disable_mosaic:
-    mosaic = MosaicTilerFactory(router_prefix="/mosaicjson")
-    app.include_router(mosaic.router, prefix="/mosaicjson", tags=["MosaicJSON"])
+    mosaic = MosaicTilerFactory(router_prefix=mosaicjson_prefix)
+    app.include_router(mosaic.router, prefix=mosaicjson_prefix, tags=["MosaicJSON"])
 
 ###############################################################################
 # TileMatrixSets endpoints
 tms = TMSFactory()
-app.include_router(tms.router, tags=["Tiling Schemes"])
+app.include_router(tms.router, prefix=global_prefix, tags=["Tiling Schemes"])
 
 ###############################################################################
 # Algorithms endpoints
 algorithms = AlgorithmFactory()
-app.include_router(algorithms.router, tags=["Algorithms"])
+app.include_router(algorithms.router, prefix=global_prefix, tags=["Algorithms"])
 
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 add_exception_handlers(app, MOSAIC_STATUS_CODES)
@@ -139,7 +163,7 @@ app.add_middleware(
 app.add_middleware(
     CacheControlMiddleware,
     cachecontrol=api_settings.cachecontrol,
-    exclude_path={r"/healthz"},
+    exclude_path={global_prefix + r"/healthz"},
 )
 
 if api_settings.debug:
@@ -150,7 +174,10 @@ if api_settings.lower_case_query_parameters:
     app.add_middleware(LowerCaseQueryStringMiddleware)
 
 
-@app.get(
+router = APIRouter(prefix=global_prefix)
+
+
+@router.get(
     "/healthz",
     description="Health Check.",
     summary="Health Check.",
@@ -162,7 +189,7 @@ def ping():
     return {"ping": "pong!"}
 
 
-@app.get("/", response_class=HTMLResponse, include_in_schema=False)
+@router.get("/", response_class=HTMLResponse, include_in_schema=False)
 def landing(request: Request):
     """TiTiler Landing page"""
     return templates.TemplateResponse(
@@ -170,3 +197,6 @@ def landing(request: Request):
         context={"request": request},
         media_type="text/html",
     )
+
+
+app.include_router(router)

--- a/src/titiler/application/titiler/application/settings.py
+++ b/src/titiler/application/titiler/application/settings.py
@@ -10,6 +10,7 @@ class ApiSettings(pydantic.BaseSettings):
     cors_origins: str = "*"
     cachecontrol: str = "public, max-age=3600"
     root_path: str = ""
+    path_prefix: str = ""
     debug: bool = False
 
     disable_cog: bool = False

--- a/src/titiler/core/pyproject.toml
+++ b/src/titiler/core/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy",
     "pydantic",
     "rasterio",
-    "rio-tiler>=4.1.6,<4.2",
+    "rio-tiler@https://github.com/SenteraLLC/rio-tiler/archive/refs/heads/4.1.10-upgrade-dev.tar.gz",
     "simplejson",
     "importlib_resources>=1.1.0;python_version<'3.9'",
     "typing_extensions;python_version<'3.8'",

--- a/src/titiler/core/pyproject.toml
+++ b/src/titiler/core/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy",
     "pydantic",
     "rasterio",
-    "rio-tiler@https://github.com/SenteraLLC/rio-tiler/archive/refs/heads/4.1.10-upgrade-dev.tar.gz",
+    "rio-tiler@https://github.com/SenteraLLC/rio-tiler/archive/refs/tags/4.1.10-0.tar.gz",
     "simplejson",
     "importlib_resources>=1.1.0;python_version<'3.9'",
     "typing_extensions;python_version<'3.8'",

--- a/src/titiler/core/titiler/core/factory.py
+++ b/src/titiler/core/titiler/core/factory.py
@@ -1,6 +1,8 @@
 """TiTiler Router factories."""
 
 import abc
+import json
+from base64 import b64decode
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple, Type, Union
 from urllib.parse import urlencode
@@ -244,6 +246,11 @@ class BaseTilerFactory(metaclass=abc.ABCMeta):
                 # https://github.com/tiangolo/fastapi/blob/58ab733f19846b4875c5b79bfb1f4d1cb7f4823f/fastapi/applications.py#L337-L360
                 # https://github.com/tiangolo/fastapi/blob/58ab733f19846b4875c5b79bfb1f4d1cb7f4823f/fastapi/routing.py#L677-L678
                 route.dependencies.extend(dependencies)  # type: ignore
+
+
+def get_feature(aoi: str) -> Feature:
+    """Base64 encoded GeoJSON Feature."""
+    return json.loads(b64decode(aoi))
 
 
 @dataclass
@@ -501,6 +508,7 @@ class TilerFactory(BaseTilerFactory):
             z: int = Path(..., ge=0, le=30, description="TMS tiles's zoom level"),
             x: int = Path(..., description="TMS tiles's column"),
             y: int = Path(..., description="TMS tiles's row"),
+            aoi: Union[str, None] = Query(default=None, description="Area of Interest"),
             TileMatrixSetId: Literal[tuple(self.supported_tms.list())] = Query(
                 self.default_tms,
                 description=f"TileMatrixSet Name (default: '{self.default_tms}')",
@@ -533,6 +541,7 @@ class TilerFactory(BaseTilerFactory):
             env=Depends(self.environment_dependency),
         ):
             """Create map tile from a dataset."""
+            feature = get_feature(aoi) if aoi else None
             tms = self.supported_tms.get(TileMatrixSetId)
             with rasterio.Env(**env):
                 with self.reader(src_path, tms=tms, **reader_params) as src_dst:
@@ -541,6 +550,7 @@ class TilerFactory(BaseTilerFactory):
                         y,
                         z,
                         tilesize=scale * 256,
+                        aoi=feature,
                         buffer=buffer,
                         **layer_params,
                         **dataset_params,

--- a/src/titiler/extensions/pyproject.toml
+++ b/src/titiler/extensions/pyproject.toml
@@ -29,7 +29,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler.core==0.11.6"
+    # Configured for volume-mount path of Lambda Dockerfile. For local
+    # development, update accordingly for your local filesystem path:
+    "titiler.core @ file:///titiler/src/titiler/core",
 ]
 
 [project.optional-dependencies]

--- a/src/titiler/mosaic/pyproject.toml
+++ b/src/titiler/mosaic/pyproject.toml
@@ -29,7 +29,9 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "titiler.core==0.11.6",
+    # Configured for volume-mount path of Lambda Dockerfile. For local
+    # development, update accordingly for your local filesystem path:
+    "titiler.core @ file:///titiler/src/titiler/core",
     "cogeo-mosaic>=5.0,<5.2",
 ]
 


### PR DESCRIPTION
**Reminder: Public repo**

## What / Why

This PR re-introduces [the changes](https://github.com/developmentseed/titiler/compare/0.6.0...SenteraLLC:path-prefix) from #1 to support an `aoi` tile clipping argument, and #2 to support hosting TiTiler on a non-root route. This work is being done in tandem with SenteraLLC/rio-tiler#2 to modernize the SenteraLLC fork of TiTiler.

I also wrote a bit of content in a new wiki: https://github.com/SenteraLLC/titiler/wiki

## QA Strategy
- [ ] Merge Latest Master
